### PR TITLE
[FP-238] Abort upload if no build artifacts are found

### DIFF
--- a/UploaderWindow.cs
+++ b/UploaderWindow.cs
@@ -77,12 +77,19 @@ public class UploaderWindow : EditorWindow
                 if (DESIRED_ARTIFACTS.Contains(buildFile.role))
                 {
                     desiredBuildFiles.Add(buildFile.path);
-                    Debug.Log(buildFile.path);
+                    Debug.Log($"Including file {buildFile.path}");
                 }
             }
 
-            Debug.Log("Beginning upload to Final Parsec.");
-            Upload(desiredBuildFiles);
+            if (desiredBuildFiles.Any())
+            {
+                Debug.Log("Beginning upload to Final Parsec.");
+                Upload(desiredBuildFiles);
+            }
+            else
+            {
+                Debug.LogError("Skipping upload to Final Parsec. No desired artifacts for upload found.");
+            }
         }
 
         if (summary.result == BuildResult.Failed)
@@ -117,7 +124,6 @@ public class UploaderWindow : EditorWindow
             Debug.Log("Game ID: " + request.downloadHandler.text);
             Debug.Log("Upload response: " + request.responseCode);
             Debug.Log("Upload result: " + request.result);
-            Debug.Log("Upload error: " + request.error);
         }
         else
         {


### PR DESCRIPTION
There are some cases where Unity may not have any desirable build artifacts produced and present in the `BuildResult`. I was able to reproduce this state when the WebGL Build Support module was installed, but editors hadn't yet been restarted.

In this state, the plugin would still attempt to move forward and upload nothing at all. This triggered an unhandled exception on the server when the files didn't pass validation. The server-side error has been fixed, but this PR modifies the plugin such that it doesn't needlessly attempt to upload nothing at all. Instead the user receives an error describing the problem in the Unity console.