### PR TITLE
[FP-338] Build role isn't correct and the plugin isn't identifying any files as a result

### DIFF
--- a/UploaderWindow.cs
+++ b/UploaderWindow.cs
@@ -26,6 +26,8 @@ public class UploaderWindow : EditorWindow
         "WebAssembly Framework",
         "Build Loader",
         "WebAssembly Code",
+        "unityweb",
+        "js",
     };
 
     Vector2 scrollPosition;
@@ -118,7 +120,6 @@ public class UploaderWindow : EditorWindow
             Debug.Log("Game ID: " + request.downloadHandler.text);
             Debug.Log("Upload response: " + request.responseCode);
             Debug.Log("Upload result: " + request.result);
-            Debug.Log("Upload error: " + request.error);
         }
         else
         {
@@ -270,5 +271,23 @@ public class UploaderWindow : EditorWindow
 
             SetEditorBuildSettingsScenes();
         }
+    }
+
+    public bool IsDesiredArtifact(BuildFile buildFile)
+    {
+        if (DESIRED_ARTIFACTS.Contains(buildFile.role))
+        {
+            return true;
+        }
+
+        if (buildFile.path.EndsWith("data.unityweb") ||
+            buildFile.path.EndsWith("framework.js.unityweb") ||
+            buildFile.path.EndsWith("loader.js") ||
+            buildFile.path.EndsWith("wasm.unityweb") )
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/UploaderWindow.cs
+++ b/UploaderWindow.cs
@@ -80,12 +80,19 @@ public class UploaderWindow : EditorWindow
                 if (DESIRED_ARTIFACTS.Contains(buildFile.role))
                 {
                     desiredBuildFiles.Add(buildFile.path);
-                    Debug.Log(buildFile.path);
+                    Debug.Log($"Including file {buildFile.path}");
                 }
             }
 
-            Debug.Log("Beginning upload to Final Parsec.");
-            Upload(desiredBuildFiles);
+            if (desiredBuildFiles.Any())
+            {
+                Debug.Log("Beginning upload to Final Parsec.");
+                Upload(desiredBuildFiles);
+            }
+            else
+            {
+                Debug.LogError("Skipping upload to Final Parsec. No desired artifacts for upload found.");
+            }
         }
 
         if (summary.result == BuildResult.Failed)


### PR DESCRIPTION
Plugin was relying on [BuildFile.role](https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildFile-role.html) in order to determine eligible files to upload the game. Unity appears to have changed these values between version 2020 and version 2021. As a result, users attempting to upload games with version 2021 of the Unity editor would attempt to upload no files and get a 400 response from the server.

This PR modifies the `DESIRED_ARTIFACTS` collection to include these new values. It also abstracts the check of whether a file is eligible or not into a separate function which has a fallback check on the file extension.

@TheMattBauer also appears to have reverted all of my changes from #1 in [this commit](https://github.com/Final-Parsec/official-plugin/commit/a01ce9dec38ac655608090b7c77cb4bb4933e0ee). I don't think he did this intentionally, so I'm adding these changes again. 